### PR TITLE
[202412][FRR]Fix memory consumption with zebra during the show ipv6 route commands in scaled setups

### DIFF
--- a/src/sonic-frr/patch/0138-Revert-vtysh-zebra-Fix-malformed-json-output-for-mul.patch
+++ b/src/sonic-frr/patch/0138-Revert-vtysh-zebra-Fix-malformed-json-output-for-mul.patch
@@ -1,0 +1,205 @@
+From a1c42960866109b31077fa9c22c0758aadc99c84 Mon Sep 17 00:00:00 2001
+From: Louis Scalbert <louis.scalbert@6wind.com>
+Date: Fri, 24 May 2024 16:46:17 +0200
+Subject: [PATCH 1/4] Revert "vtysh, zebra: Fix malformed json output for
+ multiple vrfs in command 'show ip route vrf all json'"
+
+This reverts commit 0e2fc3d67f1d358896a764373f41cb59c095eda9.
+
+This fix was correct but not optimal for memory consumption at scale.
+
+Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
+
+diff --git a/zebra/zebra_vty.c b/zebra/zebra_vty.c
+index 09fbbbdf07..020da38450 100644
+--- a/zebra/zebra_vty.c
++++ b/zebra/zebra_vty.c
+@@ -60,8 +60,8 @@ struct route_show_ctx {
+ };
+ 
+ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
+-			    safi_t safi, bool use_fib, json_object *vrf_json,
+-			    bool use_json, route_tag_t tag,
++			    safi_t safi, bool use_fib, bool use_json,
++			    route_tag_t tag,
+ 			    const struct prefix *longer_prefix_p,
+ 			    bool supernets_only, int type,
+ 			    unsigned short ospf_instance_id, uint32_t tableid,
+@@ -148,8 +148,8 @@ DEFPY (show_ip_rpf,
+ 	};
+ 
+ 	return do_show_ip_route(vty, VRF_DEFAULT_NAME, ip ? AFI_IP : AFI_IP6,
+-				SAFI_MULTICAST, false, NULL, uj, 0, NULL, false,
+-				0, 0, 0, false, &ctx);
++				SAFI_MULTICAST, false, uj, 0, NULL, false, 0, 0,
++				0, false, &ctx);
+ }
+ 
+ DEFPY (show_ip_rpf_addr,
+@@ -856,13 +856,14 @@ static void vty_show_ip_route_detail_json(struct vty *vty,
+ 	vty_json(vty, json);
+ }
+ 
+-static void
+-do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+-		     struct route_table *table, afi_t afi, bool use_fib,
+-		     json_object *vrf_json, route_tag_t tag,
+-		     const struct prefix *longer_prefix_p, bool supernets_only,
+-		     int type, unsigned short ospf_instance_id, bool use_json,
+-		     uint32_t tableid, bool show_ng, struct route_show_ctx *ctx)
++static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
++				 struct route_table *table, afi_t afi,
++				 bool use_fib, route_tag_t tag,
++				 const struct prefix *longer_prefix_p,
++				 bool supernets_only, int type,
++				 unsigned short ospf_instance_id, bool use_json,
++				 uint32_t tableid, bool show_ng,
++				 struct route_show_ctx *ctx)
+ {
+ 	struct route_node *rn;
+ 	struct route_entry *re;
+@@ -884,7 +885,7 @@ do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 	 *   => display the VRF and table if specific
+ 	 */
+ 
+-	if (use_json && !vrf_json)
++	if (use_json)
+ 		json = json_object_new_object();
+ 
+ 	/* Show all routes. */
+@@ -959,11 +960,7 @@ do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 
+ 		if (json_prefix) {
+ 			prefix2str(&rn->p, buf, sizeof(buf));
+-			if (!vrf_json)
+-				json_object_object_add(json, buf, json_prefix);
+-			else
+-				json_object_object_add(vrf_json, buf,
+-						       json_prefix);
++			json_object_object_add(json, buf, json_prefix);
+ 			json_prefix = NULL;
+ 		}
+ 	}
+@@ -972,15 +969,13 @@ do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 	 * This is an extremely expensive operation at scale
+ 	 * and non-pretty reduces memory footprint significantly.
+ 	 */
+-	if (use_json && !vrf_json) {
++	if (use_json)
+ 		vty_json_no_pretty(vty, json);
+-		json = NULL;
+-	}
+ }
+ 
+ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
+-				 afi_t afi, bool use_fib, json_object *vrf_json,
+-				 bool use_json, route_tag_t tag,
++				 afi_t afi, bool use_fib, bool use_json,
++				 route_tag_t tag,
+ 				 const struct prefix *longer_prefix_p,
+ 				 bool supernets_only, int type,
+ 				 unsigned short ospf_instance_id, bool show_ng,
+@@ -1000,15 +995,15 @@ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
+ 			continue;
+ 
+ 		do_show_ip_route(vty, zvrf_name(zvrf), afi, SAFI_UNICAST,
+-				 use_fib, vrf_json, use_json, tag,
+-				 longer_prefix_p, supernets_only, type,
+-				 ospf_instance_id, zrt->tableid, show_ng, ctx);
++				 use_fib, use_json, tag, longer_prefix_p,
++				 supernets_only, type, ospf_instance_id,
++				 zrt->tableid, show_ng, ctx);
+ 	}
+ }
+ 
+ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
+-			    safi_t safi, bool use_fib, json_object *vrf_json,
+-			    bool use_json, route_tag_t tag,
++			    safi_t safi, bool use_fib, bool use_json,
++			    route_tag_t tag,
+ 			    const struct prefix *longer_prefix_p,
+ 			    bool supernets_only, int type,
+ 			    unsigned short ospf_instance_id, uint32_t tableid,
+@@ -1043,7 +1038,7 @@ static int do_show_ip_route(struct vty *vty, const char *vrf_name, afi_t afi,
+ 		return CMD_SUCCESS;
+ 	}
+ 
+-	do_show_route_helper(vty, zvrf, table, afi, use_fib, vrf_json, tag,
++	do_show_route_helper(vty, zvrf, table, afi, use_fib, tag,
+ 			     longer_prefix_p, supernets_only, type,
+ 			     ospf_instance_id, use_json, tableid, show_ng, ctx);
+ 
+@@ -1757,7 +1752,6 @@ DEFPY (show_route,
+ 	struct route_show_ctx ctx = {
+ 		.multi = vrf_all || table_all,
+ 	};
+-	json_object *root_json = NULL;
+ 
+ 	if (!vrf_is_backend_netns()) {
+ 		if ((vrf_all || vrf_name) && (table || table_all)) {
+@@ -1779,42 +1773,25 @@ DEFPY (show_route,
+ 	}
+ 
+ 	if (vrf_all) {
+-		if (!!json)
+-			root_json = json_object_new_object();
+ 		RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name) {
+-			json_object *vrf_json = NULL;
+-
+ 			if ((zvrf = vrf->info) == NULL
+ 			    || (zvrf->table[afi][SAFI_UNICAST] == NULL))
+ 				continue;
+ 
+-			if (!!json)
+-				vrf_json = json_object_new_object();
+-
+ 			if (table_all)
+ 				do_show_ip_route_all(vty, zvrf, afi, !!fib,
+-						     vrf_json, !!json, tag,
++						     !!json, tag,
+ 						     prefix_str ? prefix : NULL,
+ 						     !!supernets_only, type,
+ 						     ospf_instance_id, !!ng,
+ 						     &ctx);
+ 			else
+ 				do_show_ip_route(vty, zvrf_name(zvrf), afi,
+-						 SAFI_UNICAST, !!fib, vrf_json,
+-						 !!json, tag,
+-						 prefix_str ? prefix : NULL,
++						 SAFI_UNICAST, !!fib, !!json,
++						 tag, prefix_str ? prefix : NULL,
+ 						 !!supernets_only, type,
+ 						 ospf_instance_id, table, !!ng,
+ 						 &ctx);
+-
+-			if (!!json)
+-				json_object_object_add(root_json,
+-						       zvrf_name(zvrf),
+-						       vrf_json);
+-		}
+-		if (!!json) {
+-			vty_json_no_pretty(vty, root_json);
+-			root_json = NULL;
+ 		}
+ 	} else {
+ 		vrf_id_t vrf_id = VRF_DEFAULT;
+@@ -1830,13 +1807,13 @@ DEFPY (show_route,
+ 			return CMD_SUCCESS;
+ 
+ 		if (table_all)
+-			do_show_ip_route_all(vty, zvrf, afi, !!fib, NULL, !!json,
+-					     tag, prefix_str ? prefix : NULL,
++			do_show_ip_route_all(vty, zvrf, afi, !!fib, !!json, tag,
++					     prefix_str ? prefix : NULL,
+ 					     !!supernets_only, type,
+ 					     ospf_instance_id, !!ng, &ctx);
+ 		else
+ 			do_show_ip_route(vty, vrf->name, afi, SAFI_UNICAST,
+-					 !!fib, NULL, !!json, tag,
++					 !!fib, !!json, tag,
+ 					 prefix_str ? prefix : NULL,
+ 					 !!supernets_only, type,
+ 					 ospf_instance_id, table, !!ng, &ctx);
+-- 
+2.50.1
+

--- a/src/sonic-frr/patch/0139-lib-add-helpers-to-print-json-keys.patch
+++ b/src/sonic-frr/patch/0139-lib-add-helpers-to-print-json-keys.patch
@@ -1,0 +1,51 @@
+From 5b5aa2e2542dcc2a7087b09ce63ec33741370db3 Mon Sep 17 00:00:00 2001
+From: Louis Scalbert <louis.scalbert@6wind.com>
+Date: Mon, 27 May 2024 10:04:14 +0200
+Subject: [PATCH 2/4] lib: add helpers to print json keys
+
+Add helpers to print json keys in order to prepare the next commits.
+
+Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
+
+diff --git a/lib/vty.c b/lib/vty.c
+index a64fc2234b..6971ca411e 100644
+--- a/lib/vty.c
++++ b/lib/vty.c
+@@ -389,6 +389,21 @@ int vty_json_no_pretty(struct vty *vty, struct json_object *json)
+ 	return vty_json_helper(vty, json, JSON_C_TO_STRING_NOSLASHESCAPE);
+ }
+ 
++
++void vty_json_key(struct vty *vty, const char *key, bool *first_key)
++{
++	vty_out(vty, "%s\"%s\":", *first_key ? "{" : ",", key);
++	*first_key = false;
++}
++
++void vty_json_close(struct vty *vty, bool first_key)
++{
++	if (first_key)
++		/* JSON was not opened */
++		vty_out(vty, "{");
++	vty_out(vty, "}\n");
++}
++
+ void vty_json_empty(struct vty *vty, struct json_object *json)
+ {
+ 	json_object *jsonobj = json;
+diff --git a/lib/vty.h b/lib/vty.h
+index a59ac7a652..6d20f4dab5 100644
+--- a/lib/vty.h
++++ b/lib/vty.h
+@@ -374,6 +374,8 @@ extern bool vty_set_include(struct vty *vty, const char *regexp);
+  */
+ extern int vty_json(struct vty *vty, struct json_object *json);
+ extern int vty_json_no_pretty(struct vty *vty, struct json_object *json);
++void vty_json_key(struct vty *vty, const char *key, bool *first_key);
++void vty_json_close(struct vty *vty, bool first_key);
+ extern void vty_json_empty(struct vty *vty, struct json_object *json);
+ /* post fd to be passed to the vtysh client
+  * fd is owned by the VTY code after this and will be closed when done
+-- 
+2.50.1
+

--- a/src/sonic-frr/patch/0140-zebra-fix-show-route-vrf-all-memory-consumption.patch
+++ b/src/sonic-frr/patch/0140-zebra-fix-show-route-vrf-all-memory-consumption.patch
@@ -1,0 +1,56 @@
+From 151d8013e1e1a961001c23c8864670239b0c0773 Mon Sep 17 00:00:00 2001
+From: Louis Scalbert <louis.scalbert@6wind.com>
+Date: Fri, 24 May 2024 17:06:59 +0200
+Subject: [PATCH 3/4] zebra: fix show route vrf all memory consumption
+
+0e2fc3d67f ("vtysh, zebra: Fix malformed json output for multiple vrfs
+in command 'show ip route vrf all json'") has been reverted in the
+previous commit. Although the fix was correct, it was consuming too muca
+memory when displaying large route tables.
+
+A root JSON object was storing all the JSON objects containing the route
+tables, each containing their respective prefixes in JSON objects. This
+resulted in excessive memory allocation for JSON objects, potentially
+leading to an out-of-memory error on the machine.
+
+To Fix the memory consumption issue for the "show ip[v6] route vrf all
+json" command, display the tables one by one and free the memory of each
+JSON object after it has been displayed.
+
+Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
+
+diff --git a/zebra/zebra_vty.c b/zebra/zebra_vty.c
+index 020da38450..f80acf2285 100644
+--- a/zebra/zebra_vty.c
++++ b/zebra/zebra_vty.c
+@@ -1746,6 +1746,7 @@ DEFPY (show_route,
+        "Nexthop Group Information\n")
+ {
+ 	afi_t afi = ipv4 ? AFI_IP : AFI_IP6;
++	bool first_vrf_json = true;
+ 	struct vrf *vrf;
+ 	int type = 0;
+ 	struct zebra_vrf *zvrf;
+@@ -1777,7 +1778,9 @@ DEFPY (show_route,
+ 			if ((zvrf = vrf->info) == NULL
+ 			    || (zvrf->table[afi][SAFI_UNICAST] == NULL))
+ 				continue;
+-
++			if (json)
++				vty_json_key(vty, zvrf_name(zvrf),
++					     &first_vrf_json);
+ 			if (table_all)
+ 				do_show_ip_route_all(vty, zvrf, afi, !!fib,
+ 						     !!json, tag,
+@@ -1793,6 +1796,8 @@ DEFPY (show_route,
+ 						 ospf_instance_id, table, !!ng,
+ 						 &ctx);
+ 		}
++		if (json)
++			vty_json_close(vty, first_vrf_json);
+ 	} else {
+ 		vrf_id_t vrf_id = VRF_DEFAULT;
+ 
+-- 
+2.50.1
+

--- a/src/sonic-frr/patch/0141-zebra-fix-show-route-memory-consumption.patch
+++ b/src/sonic-frr/patch/0141-zebra-fix-show-route-memory-consumption.patch
@@ -1,0 +1,67 @@
+From 31f157f3cf544b10061331092d32b6fd8e5c372d Mon Sep 17 00:00:00 2001
+From: Louis Scalbert <louis.scalbert@6wind.com>
+Date: Fri, 24 May 2024 16:34:23 +0200
+Subject: [PATCH 4/4] zebra: fix show route memory consumption
+
+When displaying a route table in JSON, a table JSON object is storing
+all the prefix JSON objects containing the prefix information. This
+results in excessive memory allocation for JSON objects, potentially
+leading to an out-of-memory error on the machine with large routing
+tables.
+
+To Fix the memory consumption issue for the "show ip[v6] route [vrf XX]
+json" command, display the prefixes one by one and free the memory of
+each JSON object after it has been displayed.
+
+Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>
+
+diff --git a/zebra/zebra_vty.c b/zebra/zebra_vty.c
+index f80acf2285..9392d7cf18 100644
+--- a/zebra/zebra_vty.c
++++ b/zebra/zebra_vty.c
+@@ -867,9 +867,9 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ {
+ 	struct route_node *rn;
+ 	struct route_entry *re;
++	bool first_json = true;
+ 	int first = 1;
+ 	rib_dest_t *dest;
+-	json_object *json = NULL;
+ 	json_object *json_prefix = NULL;
+ 	uint32_t addr;
+ 	char buf[BUFSIZ];
+@@ -885,9 +885,6 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 	 *   => display the VRF and table if specific
+ 	 */
+ 
+-	if (use_json)
+-		json = json_object_new_object();
+-
+ 	/* Show all routes. */
+ 	for (rn = route_top(table); rn; rn = srcdest_route_next(rn)) {
+ 		dest = rib_dest_from_rnode(rn);
+@@ -960,17 +957,15 @@ static void do_show_route_helper(struct vty *vty, struct zebra_vrf *zvrf,
+ 
+ 		if (json_prefix) {
+ 			prefix2str(&rn->p, buf, sizeof(buf));
+-			json_object_object_add(json, buf, json_prefix);
++			vty_json_key(vty, buf, &first_json);
++			vty_json_no_pretty(vty, json_prefix);
++
+ 			json_prefix = NULL;
+ 		}
+ 	}
+ 
+-	/*
+-	 * This is an extremely expensive operation at scale
+-	 * and non-pretty reduces memory footprint significantly.
+-	 */
+ 	if (use_json)
+-		vty_json_no_pretty(vty, json);
++		vty_json_close(vty, first_json);
+ }
+ 
+ static void do_show_ip_route_all(struct vty *vty, struct zebra_vrf *zvrf,
+-- 
+2.50.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -117,3 +117,7 @@
 0135-zebra-Display-interface-name-not-ifindex-in-nh-dump.patch
 0136-use-srv6-static-sids-flags-to-prevent-double-uninstall.patch
 0137-zebra-Ensure-that-the-dplane-can-send-the-full-packe.patch
+0138-Revert-vtysh-zebra-Fix-malformed-json-output-for-mul.patch
+0139-lib-add-helpers-to-print-json-keys.patch
+0140-zebra-fix-show-route-vrf-all-memory-consumption.patch
+0141-zebra-fix-show-route-memory-consumption.patch


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix memory consumption with zebra during the show ipv6 route commands in scaled setups

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added patch to fix
#### How to verify it
Running show ipv6 route json command end check zebra memory doesn't release.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

